### PR TITLE
Zustand UI state for TF selection and related bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
         "uuid": "^3.4.0",
         "uuid-mongodb": "^2.5.1",
         "winston": "^3.2.1",
-        "xlsx": "^0.17.2"
+        "xlsx": "^0.17.2",
+        "zustand": "^4.5.5"
       },
       "devDependencies": {
         "@babel/core": "^7.9.0",
@@ -17204,6 +17205,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -18720,6 +18729,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -31654,6 +31690,12 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "requires": {}
+    },
     "util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -32860,6 +32902,14 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "requires": {
+        "use-sync-external-store": "1.2.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "uuid": "^3.4.0",
     "uuid-mongodb": "^2.5.1",
     "winston": "^3.2.1",
-    "xlsx": "^0.17.2"
+    "xlsx": "^0.17.2",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -9,7 +9,7 @@ import { NetworkEditorController } from './controller';
 import DataTable, { DEF_SORT_FN, PRECISION, roundNumber } from './data-table';
 import DataDetailsPanel from './data-details-panel';
 import SearchBar from './search-bar';
-import { motifName, motifTrackLinkOut, rowId, rowTypeIdField } from '../util';
+import { motifName, motifTrackLinkOut, resultId } from '../util';
 import { useUIStateStore } from './store';
 
 import makeStyles from '@mui/styles/makeStyles';
@@ -47,7 +47,7 @@ function toTableRow(obj, type) {
   const linkOut = type !== 'CLUSTER' ? motifTrackLinkOut(name) : null;
   
   const row = {};
-  row.id = rowId(type, obj[rowTypeIdField(type)]);
+  row.id = resultId(obj);
   row.type = type;
   row.db = linkOut ? linkOut.db : null;
   row.name = type === 'MOTIF' ? motifName(name) : name;

--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -10,6 +10,7 @@ import DataTable, { DEF_SORT_FN, PRECISION, roundNumber } from './data-table';
 import DataDetailsPanel from './data-details-panel';
 import SearchBar from './search-bar';
 import { motifName, motifTrackLinkOut, rowId, rowTypeIdField } from '../util';
+import { useUIStateStore } from './store';
 
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -176,6 +177,8 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
   const [ selectedMotifOrTrack, setSelectedMotifOrTrack ] = useState();
   const [ _, forceUpdate ] = useState(0); // Dummy state to force update
 
+  const setSelectedTF = useUIStateStore((state) => state.setSelectedTF);
+
   const classes = useBottomDrawerStyles();
 
   const openRef = useRef(false);
@@ -291,13 +294,19 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
     // Update the TF in the row (UI object)
     const tfs = row.transcriptionFactors || [];
     if (tfs.length === 0) return;
-    // Reset all TFs and and flag the first one to be added to the network (if checked===true)
-    tfs.forEach((el, idx) => el.inNetwork = (idx === 0 && checked));
+    // Update the TranscriptionFactor Store
+    if (checked) {
+      // Select the first TF by default
+      setSelectedTF(row.id, tfs[0].geneID.name, true);
+    } else {
+      // Unselect all TFs from this row
+      row.transcriptionFactors.forEach(tf => setSelectedTF(row.id, tf.geneID.name, false));
+    }
     // Update the UI checked state
     triggerUpdate();
     // Update the network
     if (checked) {
-      controller.addToNetwork([row]);
+      controller.addToNetwork([{ ...row, transcriptionFactors: [tfs[0]] }]);
       await controller.applyLayout();
     } else {
       controller.removeFromNetwork([row]);
@@ -318,14 +327,14 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
   const onTFCheckChange = async (tfInfo, checked, rowId) => {
     // Find the row to update
     let row = data.find(r => r.type === type && r.id === rowId);
-    // Update the actual TF object in the row
-    const tfs = row.transcriptionFactors || [];
-    const tf = tfs.find(el => el.geneID.name === tfInfo.name);
-    tf.inNetwork = checked;
+    // Update the TranscriptionFactor Store
+    setSelectedTF(rowId, tfInfo.name, checked);
     // Update the UI checked state
     triggerUpdate();
     // Update the network
     // (do not pass the actual row, but clone it and filter out the other TFs, so only the checked/unchecked one is added/removed)
+    const tfs = row.transcriptionFactors || [];
+    const tf = tfs.find(el => el.geneID.name === tfInfo.name);
     row = { ...row, transcriptionFactors: [tf] };
     if (checked) {
       controller.addToNetwork([row]);

--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -9,6 +9,7 @@ import { NetworkEditorController } from './controller';
 import DataTable, { DEF_SORT_FN, PRECISION, roundNumber } from './data-table';
 import DataDetailsPanel from './data-details-panel';
 import SearchBar from './search-bar';
+import { updateNetworkStyle } from './network-style';
 import { motifName, motifTrackLinkOut, resultId } from '../util';
 import { useUIStateStore } from './store';
 
@@ -307,9 +308,11 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
     // Update the network
     if (checked) {
       controller.addToNetwork([{ ...row, transcriptionFactors: [tfs[0]] }]);
+      updateNetworkStyle();
       await controller.applyLayout();
     } else {
       controller.removeFromNetwork([row]);
+      updateNetworkStyle();
     }
   };
   const onRowClick = (row) => {
@@ -338,9 +341,11 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
     row = { ...row, transcriptionFactors: [tf] };
     if (checked) {
       controller.addToNetwork([row]);
+      updateNetworkStyle();
       await controller.applyLayout();
     } else {
       controller.removeFromNetwork([row]);
+      updateNetworkStyle();
     }
   };
 

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -101,12 +101,16 @@ export class NetworkEditorController {
     return this.searchController.searchClusters(query);
   }
 
+  getResultOrClusterById(id) {
+    return id.startsWith('CLUSTER') ? this.searchController.getClusterById(id) : this.searchController.getResultById(id);
+  }
+
   isDemoNetwork() {
     return Boolean(this.cy.data('demo'));
   }
 
   /**
-   * @param {*} results Only the 'transcriptionFactors' that have the 'inNetwork' flag set to true will be added
+   * @param {*} results Array of motifs/tracks/clusters with the 'transcriptionFactors' that must be added to the network.
    */
   addToNetwork(results) {
     const cy = this.cy;
@@ -162,38 +166,34 @@ export class NetworkEditorController {
       const tfArr = ele.transcriptionFactors;
       const tgtArr = ele.candidateTargetGenes;
 
-      // The TF to be added must have the 'inNetwork' flag set to true
       if (tfArr.length > 0) {
         tfArr.forEach((g1) => {
-          if (g1.inNetwork) {
-            // const g1 = tfArr[0];
-            const name1 = g1.geneID.name;
-            const node1 = getNode(name1, type, clusterCode, false); // A TF must be added even if it's not a query gene
-            // Update the 'regulatoryFunction' data field
-            node1.data('regulatoryFunction', 'regulator');
+          const name1 = g1.geneID.name;
+          const node1 = getNode(name1, type, clusterCode, false); // A TF must be added even if it's not a query gene
+          // Update the 'regulatoryFunction' data field
+          node1.data('regulatoryFunction', 'regulator');
 
-            tgtArr?.forEach((g2) => {
-              const name2 = g2.geneID.name;
-              const node2 = getNode(name2, type, clusterCode, true); // Use only the query genes for target nodes
-              if (node2) {
-                // Update the 'regulatoryFunction' data field, but only if it's not already set to 'regulator'
-                if (node2.data('regulatoryFunction') !== 'regulator') {
-                  node2.data('regulatoryFunction', 'regulated');
-                }
-                // Add an edge between the TF and the target node (prevent duplicate edges by checking the clusterCode)
-                const edge = cy.elements(`edge[source="${name1}"][target="${name2}"][clusterCode="${clusterCode}"]`);
-                if (edge.length === 0) {
-                  const data = {
-                    source: name1,
-                    target: name2,
-                    clusterNumber,
-                    clusterCode,
-                  };
-                  cy.add({ group: 'edges', data });
-                }
+          tgtArr?.forEach((g2) => {
+            const name2 = g2.geneID.name;
+            const node2 = getNode(name2, type, clusterCode, true); // Use only the query genes for target nodes
+            if (node2) {
+              // Update the 'regulatoryFunction' data field, but only if it's not already set to 'regulator'
+              if (node2.data('regulatoryFunction') !== 'regulator') {
+                node2.data('regulatoryFunction', 'regulated');
               }
-            });
-          }
+              // Add an edge between the TF and the target node (prevent duplicate edges by checking the clusterCode)
+              const edge = cy.elements(`edge[source="${name1}"][target="${name2}"][clusterCode="${clusterCode}"]`);
+              if (edge.length === 0) {
+                const data = {
+                  source: name1,
+                  target: name2,
+                  clusterNumber,
+                  clusterCode,
+                };
+                cy.add({ group: 'edges', data });
+              }
+            }
+          });
         });
       }
     });
@@ -619,7 +619,6 @@ export class NetworkEditorController {
       this.bus.emit('deletedSelectedNodes', deletedNodes);
     }
   }
-
 
   /**
    * @param {boolean} isQuery if `true`, the returned list will contain only query genes

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -57,8 +57,6 @@ export class NetworkEditorController {
     /** @type {String} */
     this.networkIDStr = cy.data('id');
 
-    this.selectedMotifs = new Set();
-
     this.searchController = new SearchController(cy, this.bus);
     this.exportController = new ExportController(this);
     this.undoHandler = new UndoHandler(this);
@@ -121,17 +119,8 @@ export class NetworkEditorController {
       genes.forEach(g => geneMap.set(g.name, g));
     }
 
-    results.forEach(ele => {
-      const type = ele.type;
-      if(type === 'MOTIF') {
-        this.selectedMotifs.add(ele.name);
-      } else if(type === 'CLUSTER') {
-        this.selectedMotifs.add(ele.motifsAndTracks[0].name);
-      }
-    });
-
-    /** Get an existing node by its name or create one and return it. Either way, it also updates the `dataSources` attribute */
-    const getNode = (name, type, clusterCode, isQuery) => {
+    /** Get an existing node by its name or create one and return it. Either way, it also updates the `resultIds` attribute */
+    const createOrUpdateNode = (name, resId, regulatoryFunction, isQuery) => {
       let node = cy.getElementById(name);
       if (node.length === 0) {
         const gene = geneMap.get(name);
@@ -143,52 +132,53 @@ export class NetworkEditorController {
           id: name,
           name,
           query,
-          regulatoryFunction: 'unknown',
+          regulatoryFunction,
           motifs: gene.motifs,
           tracks: gene.tracks,
-          dataSources: []
+          resultIds: [],
         };
         node = cy.add({ group: 'nodes', data })[0];
+        node.scratch('_isQuery', isQuery);
       } else {
         node = node[0];
       }
-      const dataSources = node.data('dataSources');
-      if (!dataSources.includes(clusterCode)) {
-        dataSources.push(clusterCode);
+      if (regulatoryFunction === 'regulator') {
+        // Force the node to be a regulator
+        node.data('regulatoryFunction', 'regulator');
+        // Add the result ID to the node's `resultIds` list
+        const resultIds = node.data('resultIds');
+        if (!resultIds.includes(resId)) {
+          resultIds.push(resId);
+        }
       }
       return node;
     };
 
     results.forEach(ele => {
-      const type = ele.type;
+      const resId = ele.id;
       const clusterNumber = ele.clusterNumber;
-      const clusterCode = ele.clusterCode;
       const tfArr = ele.transcriptionFactors;
       const tgtArr = ele.candidateTargetGenes;
 
       if (tfArr.length > 0) {
         tfArr.forEach((g1) => {
-          const name1 = g1.geneID.name;
-          const node1 = getNode(name1, type, clusterCode, false); // A TF must be added even if it's not a query gene
-          // Update the 'regulatoryFunction' data field
-          node1.data('regulatoryFunction', 'regulator');
-
+          // TF ('regulator') node
+          const name1 = g1.geneID.name; // TF name
+          createOrUpdateNode(name1, resId, 'regulator', false); // A TF must be added even if it's not a query gene
+          // Target ('regulated') nodes
           tgtArr?.forEach((g2) => {
             const name2 = g2.geneID.name;
-            const node2 = getNode(name2, type, clusterCode, true); // Use only the query genes for target nodes
+            const node2 = createOrUpdateNode(name2, resId, 'regulated', true); // Use only the query genes for target nodes
             if (node2) {
-              // Update the 'regulatoryFunction' data field, but only if it's not already set to 'regulator'
-              if (node2.data('regulatoryFunction') !== 'regulator') {
-                node2.data('regulatoryFunction', 'regulated');
-              }
-              // Add an edge between the TF and the target node (prevent duplicate edges by checking the clusterCode)
-              const edge = cy.elements(`edge[source="${name1}"][target="${name2}"][clusterCode="${clusterCode}"]`);
+              // Add an edge between the TF and the target node (prevent duplicate edges by checking the `resultTFId` attribute)
+              const edge = cy.elements(`edge[source="${name1}"][target="${name2}"][resultTFId="${resId}::${name1}"]`);
               if (edge.length === 0) {
                 const data = {
+                  id: `${name1}::${resId}::${name2}`,
                   source: name1,
                   target: name2,
                   clusterNumber,
-                  clusterCode,
+                  resultTFId: resId + '::' + name1,
                 };
                 cy.add({ group: 'edges', data });
               }
@@ -203,41 +193,36 @@ export class NetworkEditorController {
     const cy = this.cy;
 
     results.forEach(ele => {
-      const type = ele.type;
-      if(type === 'MOTIF') {
-        this.selectedMotifs.delete(ele.name);
-      } else if(type === 'CLUSTER') {
-        this.selectedMotifs.delete(ele.motifsAndTracks[0].name);
-      }
-    });
+      const resId = ele.id;
 
-    results.forEach(ele => {
-      const clusterCode = ele.clusterCode;
-      const genesArr = [...ele.transcriptionFactors, ...ele.candidateTargetGenes];
-
-      genesArr.forEach((g) => {
+      // 1: Maybe remove TF nodes and their edges
+      ele.transcriptionFactors?.forEach((g) => {
         const name = g.geneID.name;
         let node = cy.getElementById(name);
         if (node.length > 0) {
           node = node[0];
-          const dataSources = node.data('dataSources');
-          // Remove this cluster from the node's data-source list
-          const idx = dataSources.indexOf(clusterCode);
+          const resultIds = node.data('resultIds');
+          // Remove this cluster from the node's `resultIds` list
+          const idx = resultIds.indexOf(resId);
           if (idx >= 0) {
-            dataSources.splice(idx, 1);
+            resultIds.splice(idx, 1);
           }
-          if (dataSources.length === 0) {
-            cy.remove(node);
+          // Then remove the node if it has: a) no more `resultIds`, and b) no incoming edges--a regulator can also be regulated by another TF
+          if (resultIds.length === 0 && node.indegree(false) === 0) {
+            cy.remove(node); // Will remove the node and its edges
+          } else {
+            // If the TF node has not been removed because it has incoming edges, we need to update its 'regulatoryFunction'
+            if (resultIds.length === 0 && node.indegree(false) > 0) {
+              node.data('regulatoryFunction', 'regulated');
+            }
+            // If the TF node has not been removed, we need to remove the edges that have this "result Id" + "TF name" combination
+            cy.elements(`edge[resultTFId="${resId}::${name}"]`).remove();
           }
         }
       });
-      // Finally remove all isolated nodes
-      // cy.nodes('[[degree = 0]]').remove();
+      // 2: Remove all isolated (probably 'target') nodes
+      cy.nodes('[[degree = 0]]').remove();
     });
-  }
-
-  getSelectedMotifs() {
-    return [...this.selectedMotifs];
   }
 
   // _computeFCOSEidealEdgeLengthMap(clusterLabels, clusterAttr) {

--- a/src/client/components/network-editor/data-details-panel.js
+++ b/src/client/components/network-editor/data-details-panel.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 
 import { dataTableHeight } from '../defaults';
 import { logoPath, getComparator, stableSort, userSelectTextProps } from '../util';
+import { useUIStateStore } from './store';
 import { NetworkEditorController } from './controller';
 
 import { useTheme } from '@mui/material/styles';
@@ -135,7 +136,6 @@ export function DataDetailsPanel({
 }) {
   const classes = useDataDetailsPanelStyles();
   const theme = useTheme();
-  console.log('data (DataDetailsPanel):', data);
   
   const targetRows = data.candidateTargetGenes?.map(({ geneID, rank }) => {
     return {
@@ -143,11 +143,11 @@ export function DataDetailsPanel({
       name: geneID.name
     };
   });
-  const tfRows = data.transcriptionFactors?.map(({ geneID, maxMotifSimilarityFDR, minOrthologousIdentity, inNetwork }) => {
+  const tfRows = data.transcriptionFactors?.map(({ geneID, maxMotifSimilarityFDR, minOrthologousIdentity }) => {
     return {
       name: geneID.name,
       maxFDR: maxMotifSimilarityFDR,
-      minOrthologousIdentity, inNetwork
+      minOrthologousIdentity,
     };
   });
 
@@ -200,6 +200,7 @@ export function DataDetailsPanel({
       {targetRows && targetRows.length > 0 && (
         <Grid item xs={3} flexGrow={1} sx={{ height: '100%' }}>
           <GeneTable
+            parentId={data.id}
             type={subtype}
             columns={targetColumns}
             data={targetRows}
@@ -213,6 +214,7 @@ export function DataDetailsPanel({
       {tfRows && tfRows.length > 0 && (
         <Grid item xs={6} sx={{height: '100%'}}>
           <GeneTable
+            parentId={data.id}
             type={subtype}
             columns={tfColumns}
             data={tfRows}
@@ -298,9 +300,10 @@ const useGeneTableStyles = makeStyles((theme) => ({
   },
 }));
 
-function GeneTable({ type, columns, data, defOrderBy, defOrder, motifOrTrackGenes, isMobile, onRowCheckChange }) {
+function GeneTable({ parentId, type, columns, data, defOrderBy, defOrder, motifOrTrackGenes, isMobile, onRowCheckChange }) {
   const [orderBy, setOrderBy] = useState(defOrderBy);
   const [order, setOrder] = useState(defOrder);
+  const selectedTFs = useUIStateStore(state => state.selectedTFs);
 
   const classes = useGeneTableStyles();
 
@@ -322,7 +325,7 @@ function GeneTable({ type, columns, data, defOrderBy, defOrder, motifOrTrackGene
     setOrderBy(property);
   };
   const isRowChecked = (row) => {
-    return Boolean(row['inNetwork']);
+    return Boolean(selectedTFs.get(parentId)?.has(row.name));
   };
   const handleRowCheck = (row) => {
     const checked = isRowChecked(row);
@@ -471,6 +474,7 @@ function GeneTable({ type, columns, data, defOrderBy, defOrder, motifOrTrackGene
   );
 }
 GeneTable.propTypes = {
+  parentId: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   columns: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,

--- a/src/client/components/network-editor/data-table.js
+++ b/src/client/components/network-editor/data-table.js
@@ -6,6 +6,7 @@ import { dataTableHeight } from '../defaults';
 import { getComparator, stableSort } from '../util';
 import { NetworkEditorController } from './controller';
 import { clusterColor } from './network-style';
+import { useUIStateStore } from './store';
 
 import { useTheme } from '@mui/material/styles';
 
@@ -313,13 +314,14 @@ export const roundNumber = (val) => {
   return val != null ? (Math.round(val * Math.pow(10, PRECISION)) / Math.pow(10, PRECISION)) : 0;
 };
 
-const isRowChecked = (row) => {
-  return row.transcriptionFactors.some(tf => tf.inNetwork);
+const isRowChecked = (row, selectedTFs) => {
+  return row.transcriptionFactors.some(tf => selectedTFs.get(row.id)?.has(tf.geneID.name));
 };
 
 //==[ ContentRow ]====================================================================================================
 
 const ContentRow = ({ row, index, controller, isMobile, onCheck, onClick }) => {
+  const selectedTFs = useUIStateStore(state => state.selectedTFs);
   const classes = useStyles();
 
   return (
@@ -336,7 +338,7 @@ const ContentRow = ({ row, index, controller, isMobile, onCheck, onClick }) => {
           <Checkbox
             sx={{ width: 24, height: 24 }}
             disabled={row['transcriptionFactors'].length === 0}
-            checked={isRowChecked(row)}
+            checked={isRowChecked(row, selectedTFs)}
             onClick={() => onCheck(row)}
           /> 
         :
@@ -374,6 +376,7 @@ export function DataTable({
 }) {
   const [orderBy, setOrderBy] = useState(DEF_ORDER_BY);
   const [order, setOrder] = useState(DEF_ORDER);
+  const selectedTFs = useUIStateStore(state => state.selectedTFs);
 
   const classes = useStyles();
   const theme = useTheme();
@@ -409,14 +412,14 @@ export function DataTable({
   };
 
   const handleRowCheck = (row) => {
-    const checked = !isRowChecked(row);
+    const checked = !isRowChecked(row, selectedTFs);
     onRowCheckChange?.(row, checked);
   };
 
   const handleUncheckAllClick = (evt) => {
     if (sortedDataRef.current) {
       sortedDataRef.current.forEach(row => {
-        isRowChecked(row) && handleRowCheck(row);
+        isRowChecked(row, selectedTFs) && handleRowCheck(row);
       });
     }
     evt.stopPropagation();
@@ -475,7 +478,7 @@ export function DataTable({
   }
 
   const totalRows = data.length;
-  const totalCheckedRows = data.filter(row => isRowChecked(row)).length;
+  const totalCheckedRows = data.filter(row => isRowChecked(row, selectedTFs)).length;
   const allChecked = totalCheckedRows > 0 && totalCheckedRows === totalRows;
   const noneChecked = totalCheckedRows === 0;
 

--- a/src/client/components/network-editor/export-controller.js
+++ b/src/client/components/network-editor/export-controller.js
@@ -4,6 +4,7 @@ import dedent from 'dedent';
 import { logoPath } from '../util';
 // eslint-disable-next-line no-unused-vars
 import { NetworkEditorController } from './controller';
+import { useUIStateStore } from './store';
 
 
 // Sizes of exported PNG images
@@ -79,9 +80,25 @@ export class ExportController {
 
 
   async _getMotifImageBlobs() {
-    const motifs = this.controller.getSelectedMotifs();
-    const paths = motifs.map(logoPath);
-    
+    const motifs = new Set();
+    // Get all selected rows/TFs from the UI store
+    const selectedTFs = useUIStateStore.getState().selectedTFs;
+    // Filter out the tracks (includes only motifs, including those in clusters)
+    selectedTFs.forEach((tfNames, rowId) => {
+      const res = this.controller.getResultOrClusterById(rowId);
+      if (res.type === 'MOTIF') {
+        motifs.add(res.name);
+      } else if (res.type === 'CLUSTER') {
+        for (const mt of res.motifsAndTracks) {
+          if (mt.type === 'MOTIF') {
+            motifs.add(mt.name);
+          }
+        }
+      }
+    });
+    // Get the paths to the motif logos
+    const paths = Array.from(motifs).map(logoPath);
+    // Fetch the sequence logo images
     return Promise.all(
       paths.map(path => 
         fetch(path)

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -9,7 +9,8 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import { BOTTOM_DRAWER_OPEN, DEFAULT_NETWORK_TYPE_SELECTION, DEFAULT_NETWORK_TOTAL_SELECTION } from '../defaults';
 import { currentTheme } from '../../theme';
-import { isMobile, isTablet } from '../util';
+import { isMobile, isTablet, rowId, rowTypeIdField } from '../util';
+import { useUIStateStore } from './store';
 import { NetworkEditorController } from './controller';
 import Main from './main';
 
@@ -195,18 +196,16 @@ function Root({ id, theme, recentNetworksController }) {
           return true;
         }
         return false;
-      });
-      // Check whether this TF is in the gene list and, if not, get the gene object
-      // that has all the fields and add it to the list
+      })
+      .map(ele => _.cloneDeep(ele));
+      // Add only the first TF by default
       filteredResults.forEach(ele => {
-        ele.transcriptionFactors.forEach((tf, idx) => {
-          // Add only the first TF by default
-          if (idx === 0) {
-            tf.inNetwork = true;
-          } else {
-            tf.inNetwork = false;
-          }
-        });
+        ele.transcriptionFactors = ele.transcriptionFactors.slice(0, 1);
+        // Update the UI Store
+        const tf = ele.transcriptionFactors[0];
+        const type = ele.type;
+        const id = rowId(type, ele[rowTypeIdField(type)]);
+        useUIStateStore.getState().setSelectedTF(id, tf.geneID.name, true);
       });
 
   // TODO do not add to network here (?), but let the data-table do it from the cheked results (TF's 'inNetwork' field)

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -9,7 +9,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import { BOTTOM_DRAWER_OPEN, DEFAULT_NETWORK_TYPE_SELECTION, DEFAULT_NETWORK_TOTAL_SELECTION } from '../defaults';
 import { currentTheme } from '../../theme';
-import { isMobile, isTablet, rowId, rowTypeIdField } from '../util';
+import { isMobile, isTablet } from '../util';
 import { useUIStateStore } from './store';
 import { NetworkEditorController } from './controller';
 import Main from './main';
@@ -203,8 +203,7 @@ function Root({ id, theme, recentNetworksController }) {
         ele.transcriptionFactors = ele.transcriptionFactors.slice(0, 1);
         // Update the UI Store
         const tf = ele.transcriptionFactors[0];
-        const type = ele.type;
-        const id = rowId(type, ele[rowTypeIdField(type)]);
+        const id = ele.id;
         useUIStateStore.getState().setSelectedTF(id, tf.geneID.name, true);
       });
 

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -62,6 +62,8 @@ function getMinMaxValues(cy, attr) {
   };
 }
 
+// So we can update all memoize functions when necessary
+let memoizeFunctions = [];
 
 export const nodeLabel = _.memoize(node => {
   const label = node.data('label');
@@ -71,13 +73,17 @@ export const nodeLabel = _.memoize(node => {
   return name;
 }, node => node.id());
 
-export const clusterColor = (clusterNumber) => {
+export function clusterColor(clusterNumber) {
   const colorNumber = clusterNumber % CLUSTER_COLORS.length;
   const color = chroma(CLUSTER_COLORS[colorNumber]);
   return color.hex();
-};
+}
 
-export const createNetworkStyle = (cy) => {
+export function updateNetworkStyle() {
+  memoizeFunctions?.forEach(f => f.cache.clear());
+}
+
+export function createNetworkStyle(cy) {
   const { min:minNES, max:maxNES } = getMinMaxValues(cy, 'NES');
   const magNES = Math.max(Math.abs(maxNES), Math.abs(minNES));
 
@@ -107,6 +113,9 @@ export const createNetworkStyle = (cy) => {
     const cluster = e.data('clusterNumber');
     return clusterColor(cluster);
   }, e => e.id());
+
+  // Clear the memoize array
+  memoizeFunctions = [nodeLabel, getNodeColor, getNodeShape, getNodeSize, getNodeFontSize, getEdgeColor];
 
   return {
     maxNES,
@@ -210,6 +219,6 @@ export const createNetworkStyle = (cy) => {
       },
     ]
   };
-};
+}
 
 export default createNetworkStyle;

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -8,6 +8,7 @@ export const NODE_OPACITY = 1;
 export const TEXT_OPACITY = 1;
 export const SELECTED_BORDER_COLOR = '#333333';
 
+
 /** Color range for up-down regulation. */
 export const REG_COLOR_RANGE = (() => {
   // ColorBrewer 2.0 -- Diverging (Colorblind Safe)
@@ -62,16 +63,49 @@ function getMinMaxValues(cy, attr) {
   };
 }
 
-// So we can update all memoize functions when necessary
-let memoizeFunctions = [];
+// Node memoize functions
 
-export const nodeLabel = _.memoize(node => {
+const getNodeLabel = _.memoize(node => {
   const label = node.data('label');
   if (label)
     return label;
   const name = node.data('name');
   return name;
 }, node => node.id());
+
+const getNodeColor = _.memoize(node => {
+  const regFunction = node.data('regulatoryFunction');
+  // const query = node.data('query');
+  // if (query) return '#666666';
+  switch (regFunction) {
+    case 'regulator': return NODE_COLOR_REGULATOR;
+    case 'regulated': return NODE_COLOR_REGULATED;
+    default:          return NODE_COLOR_DEFAULT;
+  }
+}, n => n.id());
+
+const getNodeShape = _.memoize(n => {
+  return n.data('regulatoryFunction') === 'regulator' ? 'octagon' : 'ellipse';
+}, n => n.id());
+
+const getNodeSize = _.memoize(n => {
+  return n.data('regulatoryFunction') === 'regulator' ? 50 : 40;
+}, n => n.id());
+
+const getNodeFontSize = _.memoize(n => {
+  return n.data('regulatoryFunction') === 'regulator' ? '14px' : '10px';
+}, n => n.id());
+
+// Edge memoize functions
+
+const getEdgeColor = _.memoize(e => {
+  const cluster = e.data('clusterNumber');
+  return clusterColor(cluster);
+}, e => e.id());
+
+// So we can update all memoize functions when necessary
+const memoizeFunctions = [getNodeLabel, getNodeColor, getNodeShape, getNodeSize, getNodeFontSize, getEdgeColor];
+
 
 export function clusterColor(clusterNumber) {
   const colorNumber = clusterNumber % CLUSTER_COLORS.length;
@@ -86,36 +120,6 @@ export function updateNetworkStyle() {
 export function createNetworkStyle(cy) {
   const { min:minNES, max:maxNES } = getMinMaxValues(cy, 'NES');
   const magNES = Math.max(Math.abs(maxNES), Math.abs(minNES));
-
-  // Nodes
-  const getNodeColor = _.memoize(node => {
-    const regFunction = node.data('regulatoryFunction');
-    // const query = node.data('query');
-    // if (query) return '#666666';
-    switch (regFunction) {
-      case 'regulator': return NODE_COLOR_REGULATOR;
-      case 'regulated': return NODE_COLOR_REGULATED;
-      default:          return NODE_COLOR_DEFAULT;
-    }
-  }, n => n.id());
-  const getNodeShape = _.memoize(n => {
-    return n.data('regulatoryFunction') === 'regulator' ? 'octagon' : 'ellipse';
-  }, n => n.id());
-  const getNodeSize = _.memoize(n => {
-    return n.data('regulatoryFunction') === 'regulator' ? 50 : 40;
-  }, n => n.id());
-  const getNodeFontSize = _.memoize(n => {
-    return n.data('regulatoryFunction') === 'regulator' ? '14px' : '10px';
-  }, n => n.id());
-
-  // Edges
-  const getEdgeColor = _.memoize(e => {
-    const cluster = e.data('clusterNumber');
-    return clusterColor(cluster);
-  }, e => e.id());
-
-  // Clear the memoize array
-  memoizeFunctions = [nodeLabel, getNodeColor, getNodeShape, getNodeSize, getNodeFontSize, getEdgeColor];
 
   return {
     maxNES,
@@ -144,7 +148,7 @@ export function createNetworkStyle(cy) {
           'text-outline-color': getNodeColor,
           'shape': getNodeShape,
           'z-index': 1,
-          'label': nodeLabel,
+          'label': getNodeLabel,
         }
       },
       {

--- a/src/client/components/network-editor/search-contoller.js
+++ b/src/client/components/network-editor/search-contoller.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'eventemitter3';
 import Cytoscape from 'cytoscape'; // eslint-disable-line
 import MiniSearch from 'minisearch';
+import { rowId, rowTypeIdField } from '../util';
 
 
 export class SearchController {
@@ -58,6 +59,26 @@ export class SearchController {
       return this.resultsMiniSearch.search(query, { fields: ['name', 'description'], prefix: true });
     }
     return [];
+  }
+
+  searchClusters(query) {
+    if (!this.isResultListIndexed()) {
+      throw "The results haven't been fecthed yet!";
+    }
+    if (query && query.length > 0) {
+      return this.clustersMiniSearch.search(query, { fields: ['name', 'description'], prefix: true });
+    }
+    return [];
+  }
+
+  getResultById(id) {
+    const all = Object.values(this.resultsMiniSearch.toJSON().storedFields);
+    return all?.find(obj => obj.id === id);
+  }
+
+  getClusterById(id) {
+    const all = Object.values(this.clustersMiniSearch.toJSON().storedFields);
+    return all?.find(obj => obj.id === id);
   }
 
   getResults(type) {
@@ -130,9 +151,10 @@ export class SearchController {
 
   _indexMotifsAndTracks(documents) {
     this.resultsMiniSearch = new MiniSearch({
-      idField: 'name',
-      fields: ['name', 'description'],
+      idField: 'id',
+      fields: ['id', 'name', 'description'],
       storeFields: [
+        'id',
         'type',
         'nomenclatureCode',
         'rankingsDatabase',
@@ -155,15 +177,18 @@ export class SearchController {
         'orthologousSpecies',
       ]
     });
+    // Add an `id` field to each document
+    documents?.forEach((doc) => doc.id = rowId(doc.type, doc[rowTypeIdField(doc.type)]));
     console.log('Search docs (RESULTS)', documents);
     this.resultsMiniSearch.addAll(documents);
   }
 
   _indexClusters(documents) {
     this.clustersMiniSearch = new MiniSearch({
-      idField: 'name',
-      fields: ['name'],
+      idField: 'id',
+      fields: ['id', 'name'],
       storeFields: [
+        'id',
         'type',
         'resultType',
         'name',
@@ -175,6 +200,8 @@ export class SearchController {
         'transcriptionFactors',
       ]
     });
+    // Add an `id` field to each document
+    documents?.forEach((doc) => doc.id = rowId(doc.type, doc[rowTypeIdField(doc.type)]));
     console.log('Search docs (CLUSTERS)', documents);
     this.clustersMiniSearch.addAll(documents);
   }

--- a/src/client/components/network-editor/search-contoller.js
+++ b/src/client/components/network-editor/search-contoller.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'eventemitter3';
 import Cytoscape from 'cytoscape'; // eslint-disable-line
 import MiniSearch from 'minisearch';
-import { rowId, rowTypeIdField } from '../util';
+import { resultId } from '../util';
 
 
 export class SearchController {
@@ -178,7 +178,7 @@ export class SearchController {
       ]
     });
     // Add an `id` field to each document
-    documents?.forEach((doc) => doc.id = rowId(doc.type, doc[rowTypeIdField(doc.type)]));
+    documents?.forEach((doc) => doc.id = resultId(doc));
     console.log('Search docs (RESULTS)', documents);
     this.resultsMiniSearch.addAll(documents);
   }
@@ -201,7 +201,7 @@ export class SearchController {
       ]
     });
     // Add an `id` field to each document
-    documents?.forEach((doc) => doc.id = rowId(doc.type, doc[rowTypeIdField(doc.type)]));
+    documents?.forEach((doc) => doc.id = resultId(doc));
     console.log('Search docs (CLUSTERS)', documents);
     this.clustersMiniSearch.addAll(documents);
   }

--- a/src/client/components/network-editor/store.js
+++ b/src/client/components/network-editor/store.js
@@ -5,7 +5,6 @@ export const useUIStateStore = create((set) => ({
   selectedTFs: new Map(/**rowId: [...tfNames]*/),
   
   setSelectedTF: (rowId, tfName, selected) => set((state) => {
-    console.log('setSelectedTF', rowId, tfName, selected);
     const selectedTFs = new Map(state.selectedTFs);
     if (selected) {
       if (selectedTFs.has(rowId)) {
@@ -21,7 +20,6 @@ export const useUIStateStore = create((set) => ({
         }
       }
     }
-    console.log('selectedTFs', selectedTFs);
     return { selectedTFs };
   }),
 }));

--- a/src/client/components/network-editor/store.js
+++ b/src/client/components/network-editor/store.js
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+
+export const useUIStateStore = create((set) => ({
+  selectedTFs: new Map(/**rowId: [...tfNames]*/),
+  
+  setSelectedTF: (rowId, tfName, selected) => set((state) => {
+    console.log('setSelectedTF', rowId, tfName, selected);
+    const selectedTFs = new Map(state.selectedTFs);
+    if (selected) {
+      if (selectedTFs.has(rowId)) {
+        selectedTFs.get(rowId).add(tfName);
+      } else {
+        selectedTFs.set(rowId, new Set([tfName]));
+      }
+    } else {
+      if (selectedTFs.has(rowId)) {
+        selectedTFs.get(rowId).delete(tfName);
+        if (selectedTFs.get(rowId).size === 0) {
+          selectedTFs.delete(rowId);
+        }
+      }
+    }
+    console.log('selectedTFs', selectedTFs);
+    return { selectedTFs };
+  }),
+}));

--- a/src/client/components/util.js
+++ b/src/client/components/util.js
@@ -225,21 +225,16 @@ export function logoPath(motifName) {
   }
 }
 
-/**
- * @param {*} type 'MOTIF', 'TRACK', or 'CLUSTER'
- * @param {*} typeId the 'clusterCode' or 'rank' value, which must be unique for the type.
- * @returns the row ID which is unique for all tables/types.
- */
-export function rowId(type, typeId) {
-  return `${type.toUpperCase()}-${typeId}`;
-}
 
 /**
- * @param {*} type 'MOTIF', 'TRACK', or 'CLUSTER'
- * @returns 'clusterCode' for 'CLUSTER' and 'rank' for the rest.
+ * Creates a meaningful ID that is unique for all table rows or result entries.
+ * @param {*} obj A row or result entry object which must have the fields 'type' and 'rank' or 'clusterCode'.
+ * @returns the row/result ID which is unique for all tables/types.
  */
-export function rowTypeIdField(type) {
-  return type === 'CLUSTER' ? 'clusterCode' : 'rank';
+export function resultId(obj) {
+  const type = obj.type;
+  const typeId = type === 'CLUSTER' ? obj.clusterCode : obj.rank;
+  return `${type.toUpperCase()}-${typeId}`;
 }
 
 


### PR DESCRIPTION
Refs issues #5, #6, #12

- Adds a _UI State Store_ (by _Zustand_) to manage the TF selection state.
- Fixes removing nodes/edges after a TF is unselected.  Also changes a TF node's `regulatoryFunction` to 'regulated' if it's been unselected (in the data table) but can't be removed because it's also a target of another TF. This also allows the node that became a 'regulated' one in the updated network to be visualized properly.
- Updates the network style by clearing the cache of all memoize functions after nodes are added/removed.